### PR TITLE
Fix app generator logout button for rails version greater than 4

### DIFF
--- a/lib/generators/versacommerce_app/templates/app/views/layouts/application.html.erb
+++ b/lib/generators/versacommerce_app/templates/app/views/layouts/application.html.erb
@@ -165,7 +165,7 @@
                 </li>
                 <li class="dropdown-divider"></li>
                 <li>
-                  <%= link_to logout_path, method: :delete, class: 'dropdown-item' do %>
+                  <%= button_to logout_path, method: :delete, class: 'dropdown-item' do %>
                     <%= image_tag 'logout' %>
                     <span>Logout</span>
                   <% end %>


### PR DESCRIPTION
In rails 5+ link_to generate button with get request and ignoring method: :delete.  button_to works as expected